### PR TITLE
Add comments and trim related project list

### DIFF
--- a/src/components/CommentForm.astro
+++ b/src/components/CommentForm.astro
@@ -1,0 +1,36 @@
+---
+const comments = [
+  { name: "Nguyễn Văn A", text: "Dự án rất hữu ích, cảm ơn bạn!" },
+  { name: "Trần Thị B", text: "Mình sẽ thử áp dụng vào project của mình." },
+];
+---
+<section id="comments" class="py-12">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-2xl font-bold mb-6">Bình luận</h2>
+
+    <form class="card bg-base-100 border border-base-300 mb-6">
+      <div class="card-body space-y-4">
+        <label class="form-control">
+          <span class="label-text">Tên</span>
+          <input type="text" placeholder="Nguyễn Văn A" class="input input-bordered" />
+        </label>
+        <label class="form-control">
+          <span class="label-text">Nội dung</span>
+          <textarea rows="4" placeholder="Nhập bình luận..." class="textarea textarea-bordered"></textarea>
+        </label>
+        <div class="card-actions justify-end">
+          <button type="submit" class="btn btn-primary">Gửi</button>
+        </div>
+      </div>
+    </form>
+
+    <div class="space-y-4">
+      {comments.map((c) => (
+        <article class="border border-base-300 rounded-lg p-4" >
+          <p class="font-semibold">{c.name}</p>
+          <p class="mt-2 text-sm opacity-80">{c.text}</p>
+        </article>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/layouts/ProjectPost.astro
+++ b/src/layouts/ProjectPost.astro
@@ -5,13 +5,14 @@ import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import BackToTop from "../components/BackToTop.astro";
 import ProjectCard from "../components/ProjectCard.astro";
+import CommentForm from "../components/CommentForm.astro";
 const { content, frontmatter } = Astro.props;
 const allProjects = await getCollection("projects");
-// get 10 projects
+// get 4 related projects
 const projects = allProjects
   .filter((p) => p.data.published)
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
-  .slice(0, 10);
+  .slice(0, 4);
 const base = Astro.site?.pathname || "/";
 const fallback = `${base}img/no-image.svg`;
 const imgSrc = `${base}${frontmatter.thumbnail ?? "/img/no-image.svg"}`;
@@ -128,6 +129,7 @@ const imgSrc = `${base}${frontmatter.thumbnail ?? "/img/no-image.svg"}`;
     <h2>Mô tả</h2>
     <slot />
   </div>
+  <CommentForm />
   <section id="projects" class="fade-in">
     <h2 class="text-2xl font-bold mb-6">Code liên quan</h2>
     <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
## Summary
- add comment form component for project detail pages
- show only 4 related projects instead of 10

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8e5d4d4f88320bee7bf9fdd04c031