### PR TITLE
fix: import Disqus comments in ProjectPost layout

### DIFF
--- a/src/layouts/ProjectPost.astro
+++ b/src/layouts/ProjectPost.astro
@@ -6,7 +6,8 @@ import Footer from "../components/Footer.astro";
 import BackToTop from "../components/BackToTop.astro";
 import ProjectCard from "../components/ProjectCard.astro";
 import GiscusComments from "../components/GiscusComments.astro";
-const { content, frontmatter } = Astro.props;
+import DisqusComments from "../components/DisqusComments.astro";
+const { content, frontmatter, slug } = Astro.props;
 
 const allProjects = await getCollection("projects");
 // get 4 related projects


### PR DESCRIPTION
## Summary
- include Disqus comments component in project post layout
- expose slug prop to comments section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba4ead00648320a93df8e5465aacd2